### PR TITLE
Uitbreiding relaties voor proces toelatingen

### DIFF
--- a/ontology.ttl
+++ b/ontology.ttl
@@ -1014,6 +1014,21 @@ oe:dos_heeftBijlage a owl:ObjectProperty;
     Deze relatie geeft aan dat B een bestand is dat toegevoegd werd aan A.
     """@nl.
 
+oe:dos_heeftBriefBeslissing a owl:ObjectProperty;
+    rdfs:isDefinedBy <https://id.erfgoed.net/vocab/ontology>;
+    rdfs:label "heeft als beslissingsbrief"@nl;
+    dct:created "2020-05-28"^^xsd:date;
+    dct:modified "2020-05-28"^^xsd:date;
+    vs:term_status "testing";
+    rdfs:domain oe:Dossier;
+    rdfs:range [
+        owl:unionOf (oe:DossierAttachment oe:Poststuk)
+    ];
+    dct:description """Dossier A heeft als beslissingsbrief DossierAttachment of Poststuk B.
+    Geeft aan dat er over een bepaald dossier een beslissing werd genomen en deze beslissing
+    werd neergeschreven in brief B.
+    """@nl.
+
 oe:dos_heeftBriefInkennisstellingNietBevoegd a owl:ObjectProperty;
     rdfs:isDefinedBy <https://id.erfgoed.net/vocab/ontology>;
     rdfs:label "heeft als brief inkennisstelling niet bevoegd"@nl;

--- a/ontology.ttl
+++ b/ontology.ttl
@@ -864,15 +864,27 @@ oe:dos_handeltOver a owl:ObjectProperty;
     vs:term_status "testing";
     rdfs:domain oe:Dossier;
     rdfs:range [
-        owl:unionOf (oe:Aanduidingsobject oe:Erfgoedobject oe:Plan oe:Besluit)
+        owl:unionOf (oe:Aanduidingsobject oe:Erfgoedobject oe:Plan)
     ];
     dct:description """Dossier A handelt over object B.
     This relation indicaties that Dossier A interacts with a certain object, 
-    either an AanduidingsObject, an ErfgoedObject, a Plan or a Besluit.
+    either an AanduidingsObject, an ErfgoedObject or a Plan.
     """;
     skos:historyNote """
     Was called oe:heeftAlsOnderwerp in original draft. Changed to oe:dos_handeltOver
     on 05-11-2015.
+    """.
+
+oe:dos_handeltPrimairOver a owl:ObjectProperty;
+    rdfs:isDefinedBy <https://id.erfgoed.net/vocab/ontology>;
+    rdfs:label "handelt primair over";
+    dct:created "2020-10-26"^^xsd:date;
+    vs:term_status "testing";
+    rdfs:subPropertyOf oe:dos_handeltOver;
+    rdfs:domain oe:Dossier;
+    dct:description """Dossier A handelt primair over object B.
+    This relation indicaties that Dossier A interacts with a certain object, 
+    and that object is more relevant to the Dossier than other objects.
     """.
 
 ##### Dossier to Poststuk

--- a/ontology.ttl
+++ b/ontology.ttl
@@ -864,11 +864,11 @@ oe:dos_handeltOver a owl:ObjectProperty;
     vs:term_status "testing";
     rdfs:domain oe:Dossier;
     rdfs:range [
-        owl:unionOf (oe:Aanduidingsobject oe:Erfgoedobject)
+        owl:unionOf (oe:Aanduidingsobject oe:Erfgoedobject oe:Plan oe:Besluit)
     ];
     dct:description """Dossier A handelt over object B.
     This relation indicaties that Dossier A interacts with a certain object, 
-    either an AanduidingsObject or an ErfgoedObject.
+    either an AanduidingsObject, an ErfgoedObject, a Plan or a Besluit.
     """;
     skos:historyNote """
     Was called oe:heeftAlsOnderwerp in original draft. Changed to oe:dos_handeltOver


### PR DESCRIPTION
Uibreiding voor proces toelatingen, in de brieven verwijzen we ook naar plannen en besluiten. Er kunnen ook plannen gelinkt zijn aan het dossier die niet in de brieven voorkomen, die krijgen gewoon http://purl.org/dc/terms/relation als relatietype.

En nog een dos_heeftBriefBeslissing toegevoegd. Ik weet niet of het echt nuttig is voor elk type brief aparte relaties te voorzien. De combinatie dos_heeftBriefBeslissing met het beslissingstype geeft eigenlijk hetzelfde resultaat.